### PR TITLE
Fix COW related bugs

### DIFF
--- a/Crypto.xs
+++ b/Crypto.xs
@@ -7,7 +7,7 @@
 
 typedef unsigned char BYTE;
 
-static BYTE *S_get_key_buffer(SV *var, const char *name, bool null)
+static BYTE *S_get_key_buffer(SV *var, const char *name, bool null, bool writable)
 {
 	STRLEN len;
 	dTHX;
@@ -16,6 +16,9 @@ static BYTE *S_get_key_buffer(SV *var, const char *name, bool null)
 	}
 	if (!SvOK(var)) {
 		croak("%s cannot be undefined", name);
+	}
+	if (writable) {
+		SV_CHECK_THINKFIRST(var);
 	}
 	BYTE* buff = (BYTE*) SvPV(var, len);
 	if (len != 32) {
@@ -31,31 +34,31 @@ PROTOTYPES: DISABLED
 
 void _clamp(key)
 	CODE:
-	BYTE *key = S_get_key_buffer(ST(0), "key", false);
+	BYTE *key = S_get_key_buffer(ST(0), "key", false, true);
 	clamp25519(key);
 
 void _core(p, s, k, g)
 	CODE:
-	BYTE *p = S_get_key_buffer(ST(0), "p", false);
-	BYTE *s = S_get_key_buffer(ST(1), "s", true);
-	BYTE *k = S_get_key_buffer(ST(2), "k", false);
-	BYTE *g = S_get_key_buffer(ST(3), "g", true);
+	BYTE *p = S_get_key_buffer(ST(0), "p", false, true);
+	BYTE *s = S_get_key_buffer(ST(1), "s", true, true);
+	BYTE *k = S_get_key_buffer(ST(2), "k", false, false);
+	BYTE *g = S_get_key_buffer(ST(3), "g", true, false);
 	core25519(p, s, k, g);
 
 int _sign(v, h, x, s)
 	CODE:
-	BYTE *v = S_get_key_buffer(ST(0), "v", false);
-	BYTE *h = S_get_key_buffer(ST(1), "h", false);
-	BYTE *x = S_get_key_buffer(ST(2), "x", false);
-	BYTE *s = S_get_key_buffer(ST(3), "s", false);
+	BYTE *v = S_get_key_buffer(ST(0), "v", false, true);
+	BYTE *h = S_get_key_buffer(ST(1), "h", false, false);
+	BYTE *x = S_get_key_buffer(ST(2), "x", false, false);
+	BYTE *s = S_get_key_buffer(ST(3), "s", false, false);
 	RETVAL = sign25519(v, h, x, s);
 	OUTPUT:
 	RETVAL
 
 void _verify(y, v, h, p)
 	CODE:
-	BYTE *y = S_get_key_buffer(ST(0), "y", false);
-	BYTE *v = S_get_key_buffer(ST(1), "v", false);
-	BYTE *h = S_get_key_buffer(ST(2), "h", false);
-	BYTE *p = S_get_key_buffer(ST(3), "p", false);
+	BYTE *y = S_get_key_buffer(ST(0), "y", false, true);
+	BYTE *v = S_get_key_buffer(ST(1), "v", false, false);
+	BYTE *h = S_get_key_buffer(ST(2), "h", false, false);
+	BYTE *p = S_get_key_buffer(ST(3), "p", false, false);
 	verify25519(y, v, h, p);

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,4 +1,3 @@
-Crypto.c
 Crypto.xs
 curve25519_i64.c
 curve25519_i64.h

--- a/lib/HEAT/Crypto.pm
+++ b/lib/HEAT/Crypto.pm
@@ -94,7 +94,7 @@ sub sign($$)
 	my $h = hash($m, $y->{p});
 
 	my $v = KEYBUFF;
-	if (_sign($v, $h, $x, $r->{s})) {
+	if (_sign($v, $h, $y->{k}, $r->{s})) {
 		return $v . $h;
 	}
 


### PR DESCRIPTION
This fixes two copy-on-write related bugs, one of them causing issues on perl < 5.20, and the other on perl > 5.40.

See also https://github.com/Perl/perl5/issues/22380